### PR TITLE
Fix syntax error in `GettingStartedGuide` example

### DIFF
--- a/GettingStartedGuide/components/PlayerExample.brs
+++ b/GettingStartedGuide/components/PlayerExample.brs
@@ -28,6 +28,7 @@ sub onLoadStatusChanged()
         preload: true
       },
       ' key: "YOUR_LICENCE_KEY" ' The licence key is only required here if it wasn't added in the manifest.
+    }
 
     ' Pass the created player config to the player using the setup call.
     m.bitmovinPlayer.callFunc(m.BitmovinFunctions.SETUP, m.playerConfig)


### PR DESCRIPTION
Adding a missing closing brace.