### PR TITLE
Update BrightScript extension ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
 
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
-      "celsoaf.brightscript",
+      "RokuCommunity.brightscript",
       "ibm.output-colorizer"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.


### PR DESCRIPTION
The VSCode BrightScript extension now has a different ID.